### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages from Codex branch
+on:
+  push:
+    branches: [codex/integrate-react-component-and-update-homepage]
+  pull_request:
+    branches: [codex/integrate-react-component-and-update-homepage]
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Build and export site
+        run: |
+          npm run build
+          mkdir -p out
+          cp -r public/* out/ || true
+          cp -r .next/static out/_next/ || true
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          publish_branch: gh-pages
+


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow for automatic deploys from the Codex branch

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888140581dc83239e54cd18dec49449